### PR TITLE
[HUDI-9566] Ban schema evolution on columns with SI

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table;
 
+import org.apache.hudi.avro.AvroSchemaCompatibility;
 import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
@@ -45,6 +46,8 @@ import org.apache.hudi.common.fs.FailSafeConsistencyGuard;
 import org.apache.hudi.common.fs.OptimisticConsistencyGuard;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -102,6 +105,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -949,10 +953,75 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
       Schema writerSchema = HoodieAvroUtils.createHoodieWriteSchema(config.getSchema());
       Schema tableSchema = HoodieAvroUtils.createHoodieWriteSchema(existingTableSchema.get());
       AvroSchemaUtils.checkSchemaCompatible(tableSchema, writerSchema, shouldValidate, allowProjection, getDropPartitionColNames());
+      
+      // Check secondary index column compatibility
+      Option<HoodieIndexMetadata> indexMetadata = metaClient.getIndexMetadata();
+      if (indexMetadata.isPresent()) {
+        validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata.get());
+      }
     } catch (SchemaCompatibilityException e) {
       throw e;
     } catch (Exception e) {
       throw new SchemaCompatibilityException("Failed to read schema/check compatibility for base path " + metaClient.getBasePath(), e);
+    }
+  }
+
+  /**
+   * Validates that columns with secondary indexes are not evolved in an incompatible way.
+   *
+   * @param tableSchema the current table schema
+   * @param writerSchema the new writer schema
+   * @param indexMetadata the index metadata containing all index definitions
+   * @throws SchemaCompatibilityException if a secondary index column has incompatible evolution
+   */
+  static void validateSecondaryIndexSchemaEvolution(
+      Schema tableSchema,
+      Schema writerSchema,
+      HoodieIndexMetadata indexMetadata) throws SchemaCompatibilityException {
+    
+    // Filter for secondary index definitions
+    List<HoodieIndexDefinition> secondaryIndexDefs = indexMetadata.getIndexDefinitions().values().stream()
+        .filter(indexDef -> indexDef.getIndexType().equals(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath()))
+        .collect(Collectors.toList());
+    
+    if (secondaryIndexDefs.isEmpty()) {
+      return;
+    }
+    
+    // Create a map from source field to index name for efficient lookup
+    Map<String, String> columnToIndexName = new HashMap<>();
+    for (HoodieIndexDefinition indexDef : secondaryIndexDefs) {
+      String indexName = indexDef.getIndexName();
+      for (String sourceField : indexDef.getSourceFields()) {
+        // Note: If a column is part of multiple indexes, this will use the last one
+        // This is fine since we just need any index name for error reporting
+        columnToIndexName.put(sourceField, indexName);
+      }
+    }
+    
+    // Check each indexed column for schema evolution
+    for (Map.Entry<String, String> entry : columnToIndexName.entrySet()) {
+      String columnName = entry.getKey();
+      String indexName = entry.getValue();
+      
+      Schema.Field tableField = tableSchema.getField(columnName);
+      
+      if (tableField == null) {
+        // This shouldn't happen as indexed columns should exist in table schema
+        LOG.warn("Secondary index '{}' references non-existent column: {}", indexName, columnName);
+        continue;
+      }
+      
+      // Use AvroSchemaCompatibility's field lookup logic to handle aliases
+      Schema.Field writerField = AvroSchemaCompatibility.lookupWriterField(writerSchema, tableField);
+      
+      if (writerField != null && !tableField.schema().equals(writerField.schema())) {
+        String errorMessage = String.format(
+            "Column '%s' has secondary index '%s' and cannot evolve from schema '%s' to '%s'. "
+            + "Please drop the secondary index before changing the column type.",
+            columnName, indexName, tableField.schema(), writerField.schema());
+        throw new SchemaCompatibilityException(errorMessage);
+      }
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestHoodieTableSchemaEvolution.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestHoodieTableSchemaEvolution.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.exception.SchemaCompatibilityException;
+import org.apache.hudi.metadata.MetadataPartitionType;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link HoodieTable#validateSecondaryIndexSchemaEvolution}.
+ */
+public class TestHoodieTableSchemaEvolution {
+
+  private static final String TABLE_SCHEMA = "{"
+      + "\"type\": \"record\","
+      + "\"name\": \"test\","
+      + "\"fields\": ["
+      + "  {\"name\": \"id\", \"type\": \"int\"},"
+      + "  {\"name\": \"name\", \"type\": \"string\"},"
+      + "  {\"name\": \"age\", \"type\": \"int\"},"
+      + "  {\"name\": \"salary\", \"type\": \"double\"},"
+      + "  {\"name\": \"nullable_field\", \"type\": [\"null\", \"string\"], \"default\": null}"
+      + "]}";
+
+  @Test
+  public void testNoSecondaryIndexes() {
+    // When there are no secondary indexes, any schema evolution should be allowed
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA.replace("\"age\", \"type\": \"int\"", "\"age\", \"type\": \"long\""));
+    
+    HoodieIndexMetadata indexMetadata = new HoodieIndexMetadata(new HashMap<>());
+    
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  @Test
+  public void testNoSchemaChange() {
+    // When schema doesn't change, validation should pass even with secondary indexes
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_age", "age");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  @Test
+  public void testNonIndexedColumnEvolution() {
+    // Evolution of non-indexed columns should be allowed
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA.replace("\"name\", \"type\": \"string\"", "\"name\", \"type\": [\"null\", \"string\"]"));
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_age", "age");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidSchemaEvolutions")
+  public void testIndexedColumnTypeEvolution(String fieldName, String originalType, String evolvedType) {
+    // Type evolution of indexed columns should fail
+    String originalSchema = TABLE_SCHEMA;
+    String evolvedSchema = TABLE_SCHEMA.replace("\"" + fieldName + "\", \"type\": \"" + originalType + "\"", 
+                                                 "\"" + fieldName + "\", \"type\": \"" + evolvedType + "\"");
+    
+    Schema tableSchema = new Schema.Parser().parse(originalSchema);
+    Schema writerSchema = new Schema.Parser().parse(evolvedSchema);
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_" + fieldName, fieldName);
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    SchemaCompatibilityException exception = assertThrows(SchemaCompatibilityException.class, () -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+    
+    assertTrue(exception.getMessage().contains("secondary index"));
+    assertTrue(exception.getMessage().contains(fieldName));
+    assertTrue(exception.getMessage().contains("idx_" + fieldName));
+  }
+
+  private static Stream<Arguments> provideInvalidSchemaEvolutions() {
+    return Stream.of(
+        Arguments.of("age", "int", "long"),       // int to long
+        Arguments.of("age", "int", "double"),     // int to double
+        Arguments.of("salary", "double", "float") // double to float
+    );
+  }
+
+  @Test
+  public void testMultipleIndexesOnSameColumn() {
+    // When a column has multiple indexes, error should mention at least one
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA.replace("\"age\", \"type\": \"int\"", "\"age\", \"type\": \"long\""));
+    
+    HoodieIndexDefinition indexDef1 = createSecondaryIndexDefinition("idx_age_1", "age");
+    HoodieIndexDefinition indexDef2 = createSecondaryIndexDefinition("idx_age_2", "age");
+    
+    Map<String, HoodieIndexDefinition> indexDefs = new HashMap<>();
+    indexDefs.put("idx_age_1", indexDef1);
+    indexDefs.put("idx_age_2", indexDef2);
+    HoodieIndexMetadata indexMetadata = new HoodieIndexMetadata(indexDefs);
+    
+    SchemaCompatibilityException exception = assertThrows(SchemaCompatibilityException.class, () -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+    
+    assertTrue(exception.getMessage().contains("age"));
+    // Should contain at least one of the index names
+    assertTrue(exception.getMessage().contains("idx_age_1") || exception.getMessage().contains("idx_age_2"));
+  }
+
+  @Test
+  public void testCompoundIndex() {
+    // Test index on multiple columns - if any column evolves, should fail
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA.replace("\"age\", \"type\": \"int\"", "\"age\", \"type\": \"long\""));
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_compound", "name", "age");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    SchemaCompatibilityException exception = assertThrows(SchemaCompatibilityException.class, () -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+    
+    assertTrue(exception.getMessage().contains("age"));
+    assertTrue(exception.getMessage().contains("idx_compound"));
+  }
+
+  @Test
+  public void testFieldWithAlias() {
+    // Test schema evolution with field aliases
+    String tableSchemaStr = "{"
+        + "\"type\": \"record\","
+        + "\"name\": \"test\","
+        + "\"fields\": ["
+        + "  {\"name\": \"id\", \"type\": \"int\"},"
+        + "  {\"name\": \"old_name\", \"type\": \"string\", \"aliases\": [\"new_name\"]}"
+        + "]}";
+    
+    String writerSchemaStr = "{"
+        + "\"type\": \"record\","
+        + "\"name\": \"test\","
+        + "\"fields\": ["
+        + "  {\"name\": \"id\", \"type\": \"int\"},"
+        + "  {\"name\": \"new_name\", \"type\": \"string\"}"  // Field renamed using alias
+        + "]}";
+    
+    Schema tableSchema = new Schema.Parser().parse(tableSchemaStr);
+    Schema writerSchema = new Schema.Parser().parse(writerSchemaStr);
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_name", "old_name");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    // Should pass because the field is found via alias and type hasn't changed
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  @Test
+  public void testNullableFieldEvolution() {
+    // Test evolution from non-nullable to nullable
+    String evolvedSchema = TABLE_SCHEMA.replace("\"name\", \"type\": \"string\"", 
+                                                 "\"name\", \"type\": [\"null\", \"string\"], \"default\": null");
+    
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(evolvedSchema);
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_name", "name");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    // Making a field nullable changes its schema, so this should fail
+    SchemaCompatibilityException exception = assertThrows(SchemaCompatibilityException.class, () -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+    
+    assertTrue(exception.getMessage().contains("name"));
+    assertTrue(exception.getMessage().contains("idx_name"));
+  }
+
+  @Test
+  public void testMissingIndexedColumnInTableSchema() {
+    // Edge case: index references a column that doesn't exist in table schema
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    
+    HoodieIndexDefinition indexDef = createSecondaryIndexDefinition("idx_nonexistent", "nonexistent_column");
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(indexDef);
+    
+    // Should handle gracefully (logs warning and continues)
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  @Test
+  public void testNonSecondaryIndexDefinitions() {
+    // Test that non-secondary index definitions are ignored
+    Schema tableSchema = new Schema.Parser().parse(TABLE_SCHEMA);
+    Schema writerSchema = new Schema.Parser().parse(TABLE_SCHEMA.replace("\"age\", \"type\": \"int\"", "\"age\", \"type\": \"long\""));
+    
+    // Create an expression index (not secondary index)
+    HoodieIndexDefinition expressionIndexDef = HoodieIndexDefinition.newBuilder()
+        .withIndexName(MetadataPartitionType.EXPRESSION_INDEX.getPartitionPath() + "_expr_idx")
+        .withIndexType(MetadataPartitionType.EXPRESSION_INDEX.getPartitionPath())
+        .withSourceFields(Collections.singletonList("age"))
+        .build();
+    
+    HoodieIndexMetadata indexMetadata = createIndexMetadata(expressionIndexDef);
+    
+    // Should not throw because it's not a secondary index
+    assertDoesNotThrow(() -> 
+        HoodieTable.validateSecondaryIndexSchemaEvolution(tableSchema, writerSchema, indexMetadata));
+  }
+
+  private HoodieIndexDefinition createSecondaryIndexDefinition(String indexName, String... sourceFields) {
+    return HoodieIndexDefinition.newBuilder()
+        .withIndexName(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath() + "_" + indexName)
+        .withIndexType(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath())
+        .withSourceFields(Arrays.asList(sourceFields))
+        .build();
+  }
+
+  private HoodieIndexMetadata createIndexMetadata(HoodieIndexDefinition... indexDefs) {
+    Map<String, HoodieIndexDefinition> indexDefMap = new HashMap<>();
+    for (HoodieIndexDefinition indexDef : indexDefs) {
+      indexDefMap.put(indexDef.getIndexName(), indexDef);
+    }
+    return new HoodieIndexMetadata(indexDefMap);
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
+import scala.collection.Seq
 
 class TestSecondaryIndex extends HoodieSparkSqlTestBase {
 
@@ -747,5 +748,414 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
          | (1695091554787, 'e96c4396-3fad-413a-a942-4cb36106d720', 'rider-B', 'driver-M', 27, 'austin', 'texas')
          | """.stripMargin
     )
+  }
+
+  /**
+   * Test secondary index with nullable columns covering comprehensive scenarios for both COW and MOR:
+   * - Initial creation with null values
+   * - Delete by record key, read by data column
+   * - Update data column (null to non-null, non-null to null, null to null)
+   * - Insert data column (null/non-null)
+   * - Validate data at each step
+   * - Verify null value indexing behavior (new in HUDI-9543)
+   * - Test delete records in log files having null secondary keys
+   * - Test index reinitialization filtering delete records
+   */
+  test("Test Secondary Index With Nullable Columns") {
+    Seq("cow", "mor").foreach { tableType =>
+      testSecondaryIndexWithNullableColumns(tableType)
+    }
+  }
+
+  /**
+   * Helper method to test secondary index with nullable columns for both COW and MOR table types
+   */
+  private def testSecondaryIndexWithNullableColumns(tableType: String): Unit = {
+    withSparkSqlSessionConfig(
+      HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> "9",
+      "hoodie.embed.timeline.server" -> "false") {
+      withTempDir { tmp =>
+        val tableName = generateTableName + s"_nullable_${tableType}"
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        // Create table with nullable column
+        spark.sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  id INT,
+             |  name STRING,
+             |  description STRING,
+             |  ts LONG
+             |) USING HUDI
+             |options(
+             |  primaryKey = 'id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts',
+             |  hoodie.metadata.enable = 'true',
+             |  hoodie.metadata.record.index.enable = 'true',
+             |  hoodie.metadata.index.secondary.enable = 'true',
+             |  hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'
+             |)
+             |location '$basePath'
+             |""".stripMargin)
+
+        // Step 1: Initial Insertion with null values
+        spark.sql(
+          s"""
+             |INSERT INTO $tableName VALUES
+             |  (1, 'record1', 'description1', 1000),
+             |  (2, 'record2', NULL, 1001),
+             |  (3, 'record3', 'description3', 1002),
+             |  (4, 'record4', NULL, 1003)
+             |""".stripMargin)
+
+        // Verify initial data
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(2, "record2", null, 1001),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", null, 1003)
+        )
+
+        // Create secondary index on nullable column
+        spark.sql(s"CREATE INDEX idx_description ON $tableName (description)")
+
+        // Verify index is created
+        checkAnswer(s"SHOW INDEXES FROM $tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("secondary_index_idx_description", "secondary_index", "description"),
+          Seq("record_index", "record_index", "")
+        )
+
+        // Validate initial secondary index entries
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Verify null entries are indexed (new behavior)
+        val initialIndexEntries = getSecondaryIndexEntriesDirectly(basePath)
+        assertEquals(4, initialIndexEntries.length, "Should have 4 secondary index entries including nulls")
+        val nullEntries = initialIndexEntries.filter(_.contains(s"${SecondaryIndexKeyUtils.NULL_CHAR}${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}"))
+        assertEquals(2, nullEntries.length, "Should have 2 null secondary index entries")
+
+        // Test initial queries using secondary index
+        // TODO [HUDI-9549] predicate of is null / not null will not leverage index lookup as of today
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+          Seq(2, "record2", null, 1001),
+          Seq(4, "record4", null, 1003)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NOT NULL ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(3, "record3", "description3", 1002)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description = 'description1'")(
+          Seq(1, "record1", "description1", 1000)
+        )
+
+        // Step 2: Delete by record key whose secondary index is null and validate secondary index
+        spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+
+        // Verify data after delete
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", null, 1003)
+        )
+
+        // Validate secondary index after delete
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Test queries after delete
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+          Seq(4, "record4", null, 1003)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NOT NULL ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(3, "record3", "description3", 1002)
+        )
+
+        // Step 3: Update null to non-null
+        spark.sql(s"UPDATE $tableName SET description = 'updated_description' WHERE id = 4")
+
+        // Verify data after null to non-null update
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        // Validate secondary index after null to non-null update
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Test queries after null to non-null update
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+          // Should return empty result
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NOT NULL ORDER BY id")(
+          Seq(1, "record1", "description1", 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description = 'updated_description'")(
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        // Step 4: Update non-null to null
+        spark.sql(s"UPDATE $tableName SET description = NULL WHERE id = 1")
+
+        // Verify data after non-null to null update
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", null, 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        // Validate secondary index after non-null to null update
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Test queries after non-null to null update
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+          Seq(1, "record1", null, 1000)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NOT NULL ORDER BY id")(
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        // Step 5: Update null to null (should be no-op but validate)
+        spark.sql(s"UPDATE $tableName SET description = NULL WHERE id = 1")
+
+        // Verify data after null to null update (should remain same)
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", null, 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003)
+        )
+
+        // Validate secondary index after null to null update
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Step 6: Insert new record with null description
+        spark.sql(s"INSERT INTO $tableName VALUES (5, 'record5', NULL, 1004)")
+
+        // Verify data after inserting null
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", null, 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003),
+          Seq(5, "record5", null, 1004)
+        )
+
+        // Validate secondary index after inserting null
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Test queries after inserting null
+        // TODO [HUDI-9549]
+        // checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+        //   Seq(1, "record1", null, 1000),
+        //   Seq(5, "record5", null, 1004)
+        // )
+
+        // Step 7: Insert new record with non-null description
+        spark.sql(s"INSERT INTO $tableName VALUES (6, 'record6', 'new_description', 1005)")
+
+        // Verify data after inserting non-null
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", null, 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003),
+          Seq(5, "record5", null, 1004),
+          Seq(6, "record6", "new_description", 1005)
+        )
+
+        // Validate secondary index after inserting non-null
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Final comprehensive test queries
+        // TODO [HUDI-9549]
+        // checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NULL ORDER BY id")(
+        //   Seq(1, "record1", null, 1000),
+        //   Seq(5, "record5", null, 1004)
+        // )
+        // checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description IS NOT NULL ORDER BY id")(
+        //   Seq(3, "record3", "description3", 1002),
+        //   Seq(4, "record4", "updated_description", 1003),
+        //   Seq(6, "record6", "new_description", 1005)
+        // )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description = 'new_description'")(
+          Seq(6, "record6", "new_description", 1005)
+        )
+
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName WHERE description = 'description3'")(
+          Seq(3, "record3", "description3", 1002)
+        )
+
+        // Test index reinitialization behavior
+        // Drop and recreate index to test initialization from file slices
+        spark.sql(s"DROP INDEX idx_description ON $tableName")
+        spark.sql(s"CREATE INDEX idx_description ON $tableName (description)")
+        checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+          Seq(1, "record1", null, 1000),
+          Seq(3, "record3", "description3", 1002),
+          Seq(4, "record4", "updated_description", 1003),
+          Seq(5, "record5", null, 1004),
+          Seq(6, "record6", "new_description", 1005)
+        )
+        validateSecondaryIndexEntries(basePath, tableName)
+
+        // Additional MOR specific validations
+        if (tableType == "mor") {
+
+          // Step 8: Test delete record behavior in log files (MOR specific)
+          // Delete records in log files will have null secondary key even if the original record had a non-null value.
+          // This is important because the delete record only contains the record key, not the full record data
+
+          // First, test deleting a record with null secondary key
+          spark.sql(s"DELETE FROM $tableName WHERE id = 5")
+          checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+            Seq(1, "record1", null, 1000),
+            Seq(3, "record3", "description3", 1002),
+            Seq(4, "record4", "updated_description", 1003),
+            Seq(6, "record6", "new_description", 1005)
+          )
+          validateSecondaryIndexEntries(basePath, tableName)
+
+          // Now test deleting a record with non-null secondary key
+          spark.sql(s"DELETE FROM $tableName WHERE id = 3")
+          checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+            Seq(1, "record1", null, 1000),
+            Seq(4, "record4", "updated_description", 1003),
+            Seq(6, "record6", "new_description", 1005)
+          )
+          validateSecondaryIndexEntries(basePath, tableName)
+
+          // Insert a new record with the same secondary key as a deleted record to test behavior
+          spark.sql(s"INSERT INTO $tableName VALUES (7, 'record7', 'description3', 1006)")
+          checkAnswer(s"SELECT id, name, description, ts FROM $tableName ORDER BY id")(
+            Seq(1, "record1", null, 1000),
+            Seq(4, "record4", "updated_description", 1003),
+            Seq(6, "record6", "new_description", 1005),
+            Seq(7, "record7", "description3", 1006)
+          )
+          // Test compaction behavior
+          spark.sql(s"CALL run_compaction(table => '$tableName', op => 'schedule')")
+          spark.sql(s"CALL run_compaction(table => '$tableName', op => 'run')")
+
+          validateSecondaryIndexEntries(basePath, tableName)
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper method to validate secondary index entries in metadata
+   */
+  private def validateSecondaryIndexEntries(basePath: String, tableName: String): Unit = {
+    val expectedSecondaryKeys = spark.sql(s"SELECT _hoodie_record_key, description FROM $tableName")
+      .collect().map(row => {
+        val recordKey = row.getString(0)
+        val description = if (row.isNullAt(1)) null else row.getString(1)
+        SecondaryIndexKeyUtils.constructSecondaryIndexKey(description, recordKey)
+      })
+    val actualSecondaryKeys = spark.sql(s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7 AND key LIKE '%$SECONDARY_INDEX_RECORD_KEY_SEPARATOR%'")
+      .collect().map(indexKey => indexKey.getString(0))
+
+    assertEquals(expectedSecondaryKeys.toSet, actualSecondaryKeys.toSet,
+      s"Secondary index entries mismatch for table $tableName")
+  }
+
+  /**
+   * Helper method to get secondary index entries directly for inspection
+   */
+  private def getSecondaryIndexEntriesDirectly(basePath: String): Array[String] = {
+    spark.sql(s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7")
+      .collect()
+      .map(_.getString(0))
+      .filter(_.contains(SECONDARY_INDEX_RECORD_KEY_SEPARATOR))
+  }
+
+  test("Test Secondary Index with Schema Evolution - Column Type Change Should Fail") {
+    withTempDir { tmp =>
+      Seq("cow").foreach { tableType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        // Create table with initial schema where quantity is int
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  quantity int,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts',
+             |  hoodie.metadata.enable = 'true',
+             |  hoodie.metadata.record.index.enable = 'true',
+             |  hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+
+        // Insert initial data with integer quantities
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 20, 1001)")
+
+        // Create secondary index on quantity column
+        spark.sql(s"create index idx_quantity on $tableName (quantity)")
+
+        // Verify index exists
+        checkAnswer(s"show indexes from default.$tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("record_index", "record_index", ""),
+          Seq("secondary_index_idx_quantity", "secondary_index", "quantity")
+        )
+
+        // Try to alter table to evolve the schema where quantity changes from int to double
+        // This is normally a valid evolution (numeric widening) but should fail because quantity has a secondary index
+        val caughtException = intercept[Exception] {
+          spark.sql(s"ALTER TABLE $tableName ALTER COLUMN quantity TYPE double")
+        }
+
+        // Verify the exception is related to secondary index schema evolution
+        assertTrue(
+          caughtException.getMessage.contains("not supported for changing column 'quantity' with type 'IntegerType' to 'quantity' with type 'DoubleType'")
+          || (caughtException.getCause != null && caughtException.getCause.getMessage.contains("secondary index")),
+          s"Got unexpected exeption message: ${caughtException.getMessage}"
+        )
+
+        // Verify that the original data is still intact
+        checkAnswer(s"SELECT id, name, quantity, ts FROM $tableName ORDER BY id")(
+          Seq(1, "a1", 10, 1000),
+          Seq(2, "a2", 20, 1001)
+        )
+
+        // Drop the index and try again - should succeed
+        spark.sql(s"drop index idx_quantity on $tableName")
+
+        // Now the schema evolution should work
+        spark.sql(s"ALTER TABLE $tableName ALTER COLUMN quantity TYPE double")
+
+        // Insert data with double values
+        spark.sql(s"insert into $tableName values(3, 'a3', 30.5, 1002)")
+
+        // Verify the data includes the new record with evolved schema
+        checkAnswer(s"SELECT id, name, quantity, ts FROM $tableName ORDER BY id")(
+          Seq(1, "a1", 10.0, 1000),  // Original int values are now doubles
+          Seq(2, "a2", 20.0, 1001),
+          Seq(3, "a3", 30.5, 1002)
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

Because SI track values in its string format, while different data type with the same value semantics may have various string literal - int 10 to string is 10, while double 10 to string is 10.0 - this is what secondary index could not handle fundamentally.

We already have PR limits the column type that can create SI. This PR makes sure those column types does not evolve to some types that SI could not handle properly.

### Impact

No more schema evolution on column with SI.

### Risk level (write none, low medium or high below)

None
### Documentation Update

Need to call out the limitation in user facing doc when rolling out

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
